### PR TITLE
readonly PSM params

### DIFF
--- a/src/components/GovernanceTools.tsx
+++ b/src/components/GovernanceTools.tsx
@@ -25,7 +25,7 @@ export default function GovernanceTools(props: Props) {
         : 'text-blue-100 hover:bg-white/[0.12] hover:text-white'
     );
 
-  console.log({ status, data });
+  console.debug('render GovernanceTools', { status, data });
   if (status === 'idle') {
     return (
       <p>

--- a/src/components/ProposeParamChange.tsx
+++ b/src/components/ProposeParamChange.tsx
@@ -33,6 +33,8 @@ export default function ProposeParamChange(props: Props) {
 
   console.log('ProposeParamChange', { data, paramPatch });
 
+  const canGovern = !!props.psmCharterOfferId;
+
   function displayParam(name: string, { type, value }: ParameterValue) {
     switch (type) {
       case 'amount':
@@ -66,6 +68,7 @@ export default function ProposeParamChange(props: Props) {
   }
 
   function handleSubmit(event) {
+    event.preventDefault();
     console.log({ event });
     const offer = walletUtils.makeVoteOnParamChange(
       props.psmCharterOfferId,
@@ -74,7 +77,6 @@ export default function ProposeParamChange(props: Props) {
       minutesUntilClose
     );
     walletUtils.sendOffer(offer);
-    event.preventDefault();
   }
 
   // XXX tell user when the storage node doesn't exist, i.e. invalid anchor
@@ -85,7 +87,7 @@ export default function ProposeParamChange(props: Props) {
   // styling examples https://tailwindcss-forms.vercel.app/
   return (
     <div className="block mt-16">
-      <h2>VoteOnParamChange</h2>
+      <h2>Params</h2>
       <form onSubmit={handleSubmit}>
         {Object.entries(data.current).map(([name, value]) => (
           <label className="block" key={name}>
@@ -110,6 +112,7 @@ export default function ProposeParamChange(props: Props) {
           type="submit"
           value="Propose param change"
           className="btn-primary p-1 rounded mt-2"
+          disabled={!canGovern}
         />
       </form>
     </div>

--- a/src/components/ProposePauseOffers.tsx
+++ b/src/components/ProposePauseOffers.tsx
@@ -16,6 +16,8 @@ export default function ProposePauseOffers(props: Props) {
 
   const [minutesUntilClose, setMinutesUntilClose] = useState(10);
 
+  const canGovern = !!props.psmCharterOfferId;
+
   function handleCheckChange(event) {
     const { target } = event;
     assert(target.type === 'checkbox');
@@ -24,6 +26,7 @@ export default function ProposePauseOffers(props: Props) {
   }
 
   function handleSubmit(event) {
+    event.preventDefault();
     console.log({ event, checked, minutesUntilClose });
     const toPause = Object.entries(checked)
       .filter(([_, check]) => check)
@@ -35,13 +38,13 @@ export default function ProposePauseOffers(props: Props) {
       minutesUntilClose
     );
     walletUtils.sendOffer(offer);
-    event.preventDefault();
   }
 
   // styling examples https://tailwindcss-forms.vercel.app/
   return (
     <form className="mt-16" onSubmit={handleSubmit}>
-      <h2>VoteOnPauseOffers</h2>
+      <h2>Pause offers</h2>
+      <em>Current filter not displayed</em>
 
       <div className="block mt-2">
         {Object.keys(checked).map(str => (
@@ -73,6 +76,7 @@ export default function ProposePauseOffers(props: Props) {
         type="submit"
         value="Propose set to pause"
         className="btn-primary p-1 rounded mt-2"
+        disabled={!canGovern}
       />
     </form>
   );

--- a/src/components/PsmPanel.tsx
+++ b/src/components/PsmPanel.tsx
@@ -23,9 +23,46 @@ const anchors = [
   'USDT_grv',
 ];
 
-interface Props {}
+function Eligibility({
+  status,
+  invitation,
+  acceptedIn,
+}: ReturnType<typeof inferInvitationStatus>) {
+  switch (status) {
+    case 'nodata':
+      return <p>Loading…</p>;
+    case 'missing':
+      return (
+        <p className="rounded-lg py-5 px-6 mb-4 text-base mb-3 bg-red-100 text-red-700">
+          To govern you must first have received an invitation to the PSM
+          Charter.
+        </p>
+      );
+    case 'available':
+      return (
+        <div className="rounded-lg py-5 px-6 mb-4 text-base mb-3 bg-yellow-100 text-yellow-700">
+          To vote you will need to accept your invitation to the PSM Charter.
+          <AcceptInvitation
+            description={(invitation as any).description}
+            // TODO validate earlier that this invitation is from this contract
+            sourceContract={psmCharterInvitationSpec.instanceName}
+          />
+          And then <b>reload the page</b>.
+        </div>
+      );
+    case 'accepted':
+      return (
+        <p className="rounded-lg py-5 px-6 mb-4 text-base mb-3 bg-green-100 text-green-700">
+          You may vote using the invitation makers from offer{' '}
+          <OfferId id={acceptedIn} />
+        </p>
+      );
+    default:
+      return <strong>unknown status {status}</strong>;
+  }
+}
 
-export default function PsmPanel(_props: Props) {
+export default function PsmPanel() {
   const [anchorName, setAnchorName] = useState(anchors[0]);
   const walletUtils = useContext(WalletContext);
   const { data } = usePublishedDatum(
@@ -36,38 +73,12 @@ export default function PsmPanel(_props: Props) {
     data,
     psmCharterInvitationSpec.description
   );
-  if (invitationStatus.status === 'nodata') {
-    return <p>Loading…</p>;
-  }
-  if (invitationStatus.status === 'missing') {
-    return (
-      <p>You must first have received an invitation to the PSM Charter.</p>
-    );
-  }
-  if (invitationStatus.status === 'available') {
-    return (
-      <div>
-        To vote you will need to accept your invitation to the PSM Charter.
-        <AcceptInvitation
-          // @ts-expect-error invitation type
-          description={invitationStatus.invitation.description}
-          // TODO validate earlier that this invitation is from this contract
-          sourceContract={psmCharterInvitationSpec.instanceName}
-        />
-        And then <b>reload the page</b>.
-      </div>
-    );
-  }
 
-  assert(invitationStatus.status === 'accepted');
   const previousOfferId = invitationStatus.acceptedIn;
 
   return (
     <div>
-      <p>
-        You may vote using the invitation makers from offer{' '}
-        <OfferId id={previousOfferId} />
-      </p>
+      <Eligibility {...invitationStatus} />
       <div className="w-full mt-2">
         <Listbox
           as="div"


### PR DESCRIPTION
When debugging mainnet, I don't have a wallet that has any governance rights so I can't see the UI.

This makes the proposal UI render always, and in the case of ineligibility to govern it simply disables the buttons.