### PR TITLE
fix: remove buggy animation

### DIFF
--- a/src/components/questions.tsx
+++ b/src/components/questions.tsx
@@ -271,25 +271,27 @@ function ChoosePosition(props: {
               }
             >
               {({ checked }) => (
-                <div className="flex h-46 w-20 items-center justify-center gap-x-2">
-                  <motion.div layout="position" className="text-sm">
+                <div className="flex h-46 w-20 items-center justify-start gap-x-2 px-2">
+                  <div className="text-sm">
                     <RadioGroup.Label
                       as="p"
                       className="font-medium text-gray-900"
                     >
                       {index === 0 ? 'YES' : 'NO'}
                     </RadioGroup.Label>
-                  </motion.div>
-                  {checked && (
-                    <motion.div
-                      className="shrink-0 text-gray-900"
-                      initial={{ scale: 0 }}
-                      animate={{ scale: 1 }}
-                      transition={{ type: 'spring' }}
-                    >
-                      <FiCheck className="h-5 w-6" />
-                    </motion.div>
-                  )}
+                  </div>
+                  <div className="h-5 w-6">
+                    {checked && (
+                      <motion.div
+                        className="shrink-0 text-gray-900"
+                        initial={{ scale: 0 }}
+                        animate={{ scale: 1 }}
+                        transition={{ type: 'spring' }}
+                      >
+                        <FiCheck className="h-full w-full" />
+                      </motion.div>
+                    )}
+                  </div>
                 </div>
               )}
             </RadioGroup.Option>


### PR DESCRIPTION
fixes https://github.com/Agoric/dapp-econ-gov/issues/78

There seems to be an issue with the `layout` property when used inside the headless UI `RadioGroup` component, so this just removes it.

I was able to reproduce a similar bug (screenshot below) by:

- Creating a proposal
- Voting "yes" on the proposal
- Waiting for the voting transaction to succeed
- Clicking the "no" option in the proposal without refreshing the page

I'm not entirely sure this fixes the same issue seen by the EC but it's worth a try.

I think voting on the proposal was causing the component to re-render, and that was exposing some issue with framer's layout animation. It seemed to be applying transforms to the entire view that would animate its height but get stuck at a very low value. I tried some things from the documentation like `AnimationGroup`, but there were no obvious solutions that worked.
 
<img width="1268" alt="Screenshot 2023-11-06 at 8 40 02 PM" src="https://github.com/Agoric/dapp-econ-gov/assets/8848650/9c97c98d-4d50-4d15-a2b2-6f0de50cf3d4">
