### PR TITLE
test: added dalily emerynet tests

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  schedule:
+    - cron: '0 0 * * *'
 
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label ||
@@ -35,8 +37,12 @@ jobs:
 
       - name: Run e2e tests
         run: |
-          docker-compose -f tests/e2e/docker-compose.yml --profile synpress up --build --exit-code-from synpress
+          docker-compose -f tests/e2e/docker-compose.yml --profile $SYNPRESS_PROFILE up --build --exit-code-from synpress
         env:
+          # conditionals based on github event
+          SYNPRESS_PROFILE: ${{ github.event_name == 'schedule' && 'daily-tests' || 'synpress' }}
+          CYPRESS_AGORIC_NET: ${{ github.event_name == 'schedule' && 'emerynet' || 'local' }}
+          # for docker-compose.yml
           COMPOSE_DOCKER_CLI_BUILD: 1
           DOCKER_BUILDKIT: 1
           DOCKER_DEFAULT_PLATFORM: linux/amd64
@@ -46,6 +52,8 @@ jobs:
           ANVIL_FORK_URL: ${{ secrets.ANVIL_FORK_URL }}
           GH_PAT: ${{ secrets.GH_PAT }}
           GH_USERNAME: ${{ secrets.GH_USERNAME }}
+          GOV1_PHRASE: ${{ secrets.GOV1_PHRASE }}
+          GOV2_PHRASE: ${{ secrets.GOV2_PHRASE }}
           # cypress dashboard
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CYPRESS_PROJECT_ID: ${{ secrets.CYPRESS_PROJECT_ID }}

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Archive e2e artifacts
         uses: actions/upload-artifact@v3
-        if: always()
+        if: github.event_name != 'schedule'
         with:
           name: e2e-artifacts
           path: |

--- a/tests/e2e/docker-compose.yml
+++ b/tests/e2e/docker-compose.yml
@@ -4,6 +4,7 @@ services:
   synpress:
     profiles:
       - synpress
+      - daily-tests
     container_name: synpress
     build: ../..
     environment:
@@ -34,6 +35,10 @@ services:
       - GITHUB_REF=${GITHUB_REF}
       - GITHUB_BASE_REF=${GITHUB_BASE_REF}
       - GITHUB_HEAD_REF=${GITHUB_HEAD_REF}
+      # Variables for dapp-psm
+      - CYPRESS_AGORIC_NET=${CYPRESS_AGORIC_NET}
+      - CYPRESS_GOV1_PHRASE=${GOV1_PHRASE}
+      - CYPRESS_GOV2_PHRASE=${GOV2_PHRASE}
       - SECRET_WORDS="orbit bench unit task food shock brand bracket domain regular warfare company announce wheel grape trust sphere boy doctor half guard ritual three ecology"
     depends_on:
       - display
@@ -45,13 +50,14 @@ services:
       - ./docker/videos:/app/tests/e2e/videos
       - ./docker/screenshots:/app/tests/e2e/screenshots
     command: >
-      bash -c 'echo -n "======> local noVNC URL: http://localhost:8080/vnc.html?autoconnect=true " && pnpm wait-on http://display:8080 && echo -n "======> remote noVNC URL: " && curl -s ngrok:4040/api/tunnels | jq -r .tunnels[0].public_url && nginx && yarn test:e2e:ci'
+      bash -c 'echo -n "======> local noVNC URL: http://localhost:8080/vnc.html?autoconnect=true " && pnpm wait-on http://display:8080 && echo -n "======> remote noVNC URL: " && curl -s ngrok:4040/api/tunnels | jq -r .tunnels[0].public_url && if [ "$CYPRESS_AGORIC_NET" == "local" ]; then nginx; fi && yarn test:e2e:ci'
     networks:
       - x11
 
   display:
     profiles:
       - synpress
+      - daily-tests
     container_name: display
     image: synthetixio/display:016121eafdfff448414894d0ca5a50b1d72b62eb-base
     environment:
@@ -82,6 +88,7 @@ services:
   video:
     profiles:
       - synpress
+      - daily-tests
     container_name: video
     image: synthetixio/video:457bb48776c3b14de232d9dda620ba9188dc40ac-base
     volumes:

--- a/tests/e2e/specs/proposal.spec.js
+++ b/tests/e2e/specs/proposal.spec.js
@@ -1,70 +1,38 @@
 /* eslint-disable ui-testing/no-disabled-tests */
-describe('Tests for creating proposals', () => {
+describe('Make Proposal Tests', () => {
   let startTime;
-  context('Setting up accounts', () => {
-    it('should set up wallets for two members of the econ committee.', () => {
+  context('PSM tests', () => {
+    it('should setup two econ committee member wallets', () => {
       cy.setupWallet({
         secretWords:
           'purse park grow equip size away dismiss used evolve live blouse scorpion enjoy crunch combine day second news off crowd broken crop zoo subject',
-        walletName: 'gov2',
+        walletName: 'gov1',
       });
       cy.setupWallet({
         secretWords:
           'tilt add stairs mandate extra wash choose fashion earth feature reopen until move lazy carbon pledge sure own comfort this nasty clap tower table',
-        walletName: 'gov1',
+        walletName: 'gov2',
       });
     });
 
-    it('should connect with chain and wallet', () => {
+    it('should connect to wallet', () => {
       cy.visit('/?agoricNet=local');
       cy.acceptAccess();
     });
-  });
 
-  context('Adjusting Vault Params', () => {
     it('should allow gov1 to create a proposal', () => {
-      cy.visit('/?agoricNet=local');
-      cy.acceptAccess();
+      // open PSM and select USDT_axl
+      cy.get('button').contains('PSM').click();
+      cy.get('button').contains('AUSD').click();
+      cy.get('button').contains('USDT_axl').click();
 
-      cy.get('button').contains('Vaults').click();
-      cy.get('button').contains('Select Manager').click();
-      cy.get('button').contains('manager0').click();
-
+      // Change mint limit to 100 and proposal time to 1 min
       cy.get('label')
-        .contains('LiquidationMargin')
+        .contains('Set Mint Limit')
         .parent()
         .within(() => {
-          cy.get('input').clear().type('150');
+          cy.get('input').clear().type(100);
         });
-
-      cy.get('label')
-        .contains('LiquidationPadding')
-        .parent()
-        .within(() => {
-          cy.get('input').clear().type('25');
-        });
-
-      cy.get('label')
-        .contains('LiquidationPenalty')
-        .parent()
-        .within(() => {
-          cy.get('input').clear().type('1');
-        });
-
-      cy.get('label')
-        .contains('StabilityFee')
-        .parent()
-        .within(() => {
-          cy.get('input').clear().type('1');
-        });
-
-      cy.get('label')
-        .contains('MintFee')
-        .parent()
-        .within(() => {
-          cy.get('input').clear().type('0.5');
-        });
-
       cy.get('label')
         .contains('Minutes until close of vote')
         .parent()
@@ -73,6 +41,7 @@ describe('Tests for creating proposals', () => {
         });
       cy.get('[value="Propose Parameter Change"]').click();
 
+      // Submit proposal and wait for confirmation
       cy.confirmTransaction();
       cy.get('p')
         .contains('sent')
@@ -82,37 +51,44 @@ describe('Tests for creating proposals', () => {
         });
     });
 
-    it('should allow gov1 to vote on the proposal', () => {
+    it('should allow gov2 to vote on the proposal', () => {
       cy.visit('/?agoricNet=local');
 
+      // Open vote, click on yes and submit
       cy.get('button').contains('Vote').click();
       cy.get('p').contains('YES').click();
       cy.get('input:enabled[value="Submit Vote"]').click();
 
+      // Wait for vote to confirm
       cy.confirmTransaction();
       cy.get('p').contains('sent').should('be.visible');
     });
 
-    it('should allow gov2 to vote on the proposal', () => {
-      cy.switchWallet('gov2');
+    it('should allow gov1 to vote on the proposal', () => {
+      cy.switchWallet('gov1');
       cy.visit('/?agoricNet=local');
 
+      // Open vote, click on yes and submit
       cy.get('button').contains('Vote').click();
       cy.get('p').contains('YES').click();
       cy.get('input:enabled[value="Submit Vote"]').click();
 
+      // Wait for vote to confirm
       cy.confirmTransaction();
       cy.get('p').contains('sent').should('be.visible');
     });
 
     it('should wait for proposal to pass', () => {
+      // Wait for 1 minute to pass
       cy.wait(60000 - Date.now() + startTime);
       cy.visit('/?agoricNet=local');
 
       cy.get('button').contains('History').click();
 
+      // Select the first element proposal containing USDT_axl and check
+      // its status should be accepted
       cy.get('code')
-        .contains('VaultFactory - ATOM')
+        .contains('psm-IST-USDT_axl')
         .parent()
         .parent()
         .parent()
@@ -122,42 +98,22 @@ describe('Tests for creating proposals', () => {
     });
   });
 
-  context('Adjusting Auction Params', () => {
-    it('should allow gov2 to create a proposal', () => {
+  context('Vaults tests', () => {
+    it('should allow gov1 to create a proposal', () => {
       cy.visit('/?agoricNet=local');
 
+      // open Values and select manager 0
       cy.get('button').contains('Vaults').click();
-      cy.get('button').contains('Change Manager Params').click();
-      cy.get('button').contains('Change Auctioneer Params').click();
+      cy.get('button').contains('Select Manager').click();
+      cy.get('button').contains('manager0').click();
 
+      // Change debt limit to 1.22M and proposal time to 1 min
       cy.get('label')
-        .contains('StartingRate')
+        .contains('DebtLimit')
         .parent()
         .within(() => {
-          cy.get('input').clear().type('105');
+          cy.get('input').clear().type('122,000,000');
         });
-
-      cy.get('label')
-        .contains('LowestRate')
-        .parent()
-        .within(() => {
-          cy.get('input').clear().type('65');
-        });
-
-      cy.get('label')
-        .contains('DiscountStep')
-        .parent()
-        .within(() => {
-          cy.get('input').clear().type('5');
-        });
-
-      cy.get('label')
-        .contains('AuctionStartDelay')
-        .parent()
-        .within(() => {
-          cy.get('input').clear().type('2');
-        });
-
       cy.get('label')
         .contains('Minutes until close of vote')
         .parent()
@@ -166,6 +122,7 @@ describe('Tests for creating proposals', () => {
         });
       cy.get('[value="Propose Parameter Change"]').click();
 
+      // Submit proposal and wait for confirmation
       cy.confirmTransaction();
       cy.get('p')
         .contains('sent')
@@ -175,35 +132,42 @@ describe('Tests for creating proposals', () => {
         });
     });
 
-    it('should allow gov2 to vote on the proposal', () => {
+    it('should allow gov1 to vote on the proposal', () => {
       cy.visit('/?agoricNet=local');
 
+      // Open vote, click on yes and submit
       cy.get('button').contains('Vote').click();
       cy.get('p').contains('YES').click();
       cy.get('input:enabled[value="Submit Vote"]').click();
 
+      // Wait for vote to confirm
       cy.confirmTransaction();
       cy.get('p').contains('sent').should('be.visible');
     });
 
-    it('should allow gov1 to vote on the proposal', () => {
-      cy.switchWallet('gov1');
+    it('should allow gov2 to vote on the proposal', () => {
+      cy.switchWallet('gov2');
       cy.visit('/?agoricNet=local');
 
+      // Open vote, click on yes and submit
       cy.get('button').contains('Vote').click();
       cy.get('p').contains('YES').click();
       cy.get('input:enabled[value="Submit Vote"]').click();
 
+      // Wait for vote to confirm
       cy.confirmTransaction();
       cy.get('p').contains('sent').should('be.visible');
     });
 
     it('should wait for proposal to pass', () => {
+      // Wait for 1 minute to pass
       cy.wait(60000 - Date.now() + startTime);
       cy.visit('/?agoricNet=local');
 
       cy.get('button').contains('History').click();
 
+      // Select the first element proposal containing ATOM and check
+      // its status should be accepted
       cy.get('code')
         .contains('VaultFactory - ATOM')
         .parent()

--- a/tests/e2e/utils.js
+++ b/tests/e2e/utils.js
@@ -1,0 +1,29 @@
+export const DEFAULT_TIMEOUT = 2 * 60_000;
+
+export const phrasesList = {
+  emerynet: {
+    isLocal: false,
+    minutes: 3,
+    token: 'ToyUSD',
+    network: 'emerynet',
+    gov1Phrase: Cypress.env('GOV1_PHRASE'),
+    gov2Phrase: Cypress.env('GOV2_PHRASE'),
+  },
+  local: {
+    isLocal: true,
+    minutes: 1,
+    token: 'USDT_axl',
+    network: 'local',
+    gov1Phrase:
+      'purse park grow equip size away dismiss used evolve live blouse scorpion enjoy crunch combine day second news off crowd broken crop zoo subject',
+    gov2Phrase:
+      'tilt add stairs mandate extra wash choose fashion earth feature reopen until move lazy carbon pledge sure own comfort this nasty clap tower table',
+  },
+};
+
+export const getTimeUntilVoteClose = (startTime, minutesForVote) => {
+  const totalVoteTime = 60_000 * minutesForVote;
+  const voteCloseTime = totalVoteTime + startTime;
+  const currentTime = Date.now();
+  return voteCloseTime - currentTime;
+};


### PR DESCRIPTION
The main goal of this PR is to perform econ-gov tests on emerynet
To acheive this, this pr:
- reverts #92 to simplify tests (liquidation tests are not needed here anymore since they have been in another repo)
- updates tests so that they work with emerynet as well
- updated workflow file to disable artifacts archiving when emerynet mnemonics are used. This is to prevent the mnemonics from being leaked accidentally

To make this PR work when merged, two github  secrets have to be added:
`GOV1_PHRASE` and `GOV2_PHRASE` which are the memonic phrases for gov1 and gov2 respectively
