### PR TITLE
ci: upload artifacts for emerynet tests to GCS

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -17,6 +17,10 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+
     env:
       IS_EMERYNET_TEST: github.event_name == 'schedule'
 
@@ -37,6 +41,13 @@ jobs:
           key: ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
+
+      - name: 'GCP auth'
+        uses: 'google-github-actions/auth@v2'
+        if: env.IS_EMERYNET_TEST
+        with:
+          project_id: 'simulationlab'
+          workload_identity_provider: 'projects/60745596728/locations/global/workloadIdentityPools/github/providers/dapp-econ-gov'
 
       - name: Run e2e tests
         run: |
@@ -64,7 +75,7 @@ jobs:
           COMMIT_INFO_MESSAGE: ${{ github.event.pull_request.title }}
           COMMIT_INFO_SHA: ${{ github.event.pull_request.head.sha }}
 
-      - name: Archive e2e artifacts
+      - name: Archive e2e artifacts locally
         uses: actions/upload-artifact@v3
         if: ${{ !env.IS_EMERYNET_TEST  }}
         with:
@@ -73,3 +84,15 @@ jobs:
             tests/e2e/docker/videos
             tests/e2e/docker/screenshots
         continue-on-error: true
+
+      - name: Archive e2e artifacts to GCS
+        uses: google-github-actions/upload-cloud-storage@v2
+        if: env.IS_EMERYNET_TEST
+        with:
+          path: 'tests/e2e/docker'
+          destination: 'github-artifacts/${{ github.repository }}/${{ github.run_id }}/${{ github.event.repository.updated_at }}'
+        continue-on-error: true
+
+      - name: Log Path to GCS Artifacts
+        if: env.IS_EMERYNET_TEST
+        run: echo "https://console.cloud.google.com/storage/browser/github-artifacts/${{ github.repository }}/${{ github.run_id }}/${{ github.event.repository.updated_at }}/docker/videos"


### PR DESCRIPTION
Fixes #98 

Allows us to upload the video artifacts for emerynet tests to a private GCS bucket