### PR TITLE
ci: fixed issue of artifact upload not working on test fail

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -22,7 +22,7 @@ jobs:
       id-token: 'write'
 
     env:
-      IS_EMERYNET_TEST: github.event_name == 'schedule'
+      IS_EMERYNET_TEST: ${{ github.event_name == 'schedule' }}
 
     steps:
       - name: Checkout
@@ -44,7 +44,7 @@ jobs:
 
       - name: 'GCP auth'
         uses: 'google-github-actions/auth@v2'
-        if: env.IS_EMERYNET_TEST
+        if: ${{ env.IS_EMERYNET_TEST == 'true' }}
         with:
           project_id: 'simulationlab'
           workload_identity_provider: 'projects/60745596728/locations/global/workloadIdentityPools/github/providers/dapp-econ-gov'
@@ -54,8 +54,8 @@ jobs:
           docker-compose -f tests/e2e/docker-compose.yml --profile $SYNPRESS_PROFILE up --build --exit-code-from synpress
         env:
           # conditionals based on github event
-          SYNPRESS_PROFILE: ${{ env.IS_EMERYNET_TEST && 'daily-tests' || 'synpress' }}
-          CYPRESS_AGORIC_NET: ${{ env.IS_EMERYNET_TEST && 'emerynet' || 'local' }}
+          SYNPRESS_PROFILE: ${{ env.IS_EMERYNET_TEST == 'true' && 'daily-tests' || 'synpress' }}
+          CYPRESS_AGORIC_NET: ${{ env.IS_EMERYNET_TEST == 'true' && 'emerynet' || 'local' }}
           # for docker-compose.yml
           COMPOSE_DOCKER_CLI_BUILD: 1
           DOCKER_BUILDKIT: 1
@@ -77,7 +77,7 @@ jobs:
 
       - name: Archive e2e artifacts locally
         uses: actions/upload-artifact@v3
-        if: ${{ !env.IS_EMERYNET_TEST  }}
+        if: ${{ env.IS_EMERYNET_TEST == 'false' && !cancelled()}}
         with:
           name: e2e-artifacts
           path: |
@@ -87,12 +87,12 @@ jobs:
 
       - name: Archive e2e artifacts to GCS
         uses: google-github-actions/upload-cloud-storage@v2
-        if: env.IS_EMERYNET_TEST
+        if: ${{ env.IS_EMERYNET_TEST == 'true' && !cancelled() }}
         with:
           path: 'tests/e2e/docker'
           destination: 'github-artifacts/${{ github.repository }}/${{ github.run_id }}/${{ github.event.repository.updated_at }}'
         continue-on-error: true
 
       - name: Log Path to GCS Artifacts
-        if: env.IS_EMERYNET_TEST
+        if: ${{ env.IS_EMERYNET_TEST == 'true' && !cancelled() }}
         run: echo "https://console.cloud.google.com/storage/browser/github-artifacts/${{ github.repository }}/${{ github.run_id }}/${{ github.event.repository.updated_at }}/docker/videos"


### PR DESCRIPTION
This PR fixes an issue in "E2E test" github action where the artifact upload step is not running because a previous step failed. this is fixed by introducing the `!cancelled()` condition which allows us to run a step even if the prev steps have failed (`cancelled()` is only true if the user manually cancelled the job). This issue can be seen in this [action](https://github.com/Agoric/dapp-econ-gov/actions/runs/8903179222)

It also fixes an issue found with the boolean check of `env.IS_EMERYNET_TEST` which was expected to be a boolean but is actually a string, so checks have been updated accordingly