### PR TITLE
ci: add manual trigger for e2e tests workflow

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -7,6 +7,16 @@ on:
     branches: [main]
   schedule:
     - cron: '0 0 * * *'
+  workflow_dispatch:
+    inputs:
+      network:
+        description: 'Network'
+        required: false
+        default: 'emerynet'
+        type: choice
+        options:
+          - local
+          - emerynet
 
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label ||
@@ -22,7 +32,7 @@ jobs:
       id-token: 'write'
 
     env:
-      IS_EMERYNET_TEST: ${{ github.event_name == 'schedule' }}
+      IS_EMERYNET_TEST: ${{ github.event_name == 'schedule' || inputs.network == 'emerynet' }}
 
     steps:
       - name: Checkout


### PR DESCRIPTION
This PR allows you to manually trigger the e2e workflow