### PR TITLE
update agoric/synpress and address e2e tests failure with a3p:latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,13 @@ Launch pointing to your localhost:
 open http://127.0.0.1:5173/?agoricNet=local
 ```
 
-## Testing
+# E2E Testing
 
 E2E tests have been written in order to test the dapp as well as to perform automated testing on emerynet/devnet when upgrading the chain
 
 There are two ways to run the tests:
 
-### On Local Machine
+## On Local Machine
 
 To run tests on your local machine, first you need to start the frontend server:
 
@@ -71,7 +71,7 @@ docker compose -f tests/e2e/docker-compose.yml up -d agd
 
 Note: the tests use chrome browser by default so they require it to be installed
 
-### On Github
+## On Github
 
 To run the tests on github, you can use the workflow trigger to run the tests.
 

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   },
   "devDependencies": {
     "@agoric/governance": "^0.10.3",
-    "@agoric/synpress": "^3.7.2-beta.12",
+    "@agoric/synpress": "^3.8.3-beta.2",
     "@keplr-wallet/types": "^0.11.1",
     "@tailwindcss/forms": "^0.5.3",
     "@types/node": "^18.7.13",

--- a/tests/e2e/utils.js
+++ b/tests/e2e/utils.js
@@ -25,9 +25,9 @@ export const phrasesList = {
     token: 'USDT_axl',
     network: 'local',
     gov1Phrase:
-      'purse park grow equip size away dismiss used evolve live blouse scorpion enjoy crunch combine day second news off crowd broken crop zoo subject',
+      'such field health riot cost kitten silly tube flash wrap festival portion imitate this make question host bitter puppy wait area glide soldier knee',
     gov2Phrase:
-      'tilt add stairs mandate extra wash choose fashion earth feature reopen until move lazy carbon pledge sure own comfort this nasty clap tower table',
+      'physical immune cargo feel crawl style fox require inhale law local glory cheese bring swear royal spy buyer diesel field when task spin alley',
   },
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -298,10 +298,10 @@
   resolved "https://registry.yarnpkg.com/@agoric/swingset-xsnap-supervisor/-/swingset-xsnap-supervisor-0.10.2.tgz#09f067695b0ea6ebfeb6ea200cc7f1675f0f8939"
   integrity sha512-3PB15aiNHfjTYmtUz9Rxmm6qSHnoO5w5dygRzjx2ytk8yoNn/ZOpxlIOLonhD8kwOaEli5D7btY9OA3jf+Sm6w==
 
-"@agoric/synpress@^3.7.2-beta.12":
-  version "3.7.2-beta.12"
-  resolved "https://registry.yarnpkg.com/@agoric/synpress/-/synpress-3.7.2-beta.12.tgz#1a1d35c3c2c56e985630e0cd4c05039b8b6878b3"
-  integrity sha512-mSDc0IJLdNIXF5re6Bd/7NBXjyeGTNRIji69ZpflikY4BuQpxaQdfvK3TOsdWfs74Z5ReIXADly9YYOuhbkdLw==
+"@agoric/synpress@^3.8.3-beta.2":
+  version "3.8.3-beta.2"
+  resolved "https://registry.yarnpkg.com/@agoric/synpress/-/synpress-3.8.3-beta.2.tgz#174c382c720827b0cfd932edb5332fda40f9d260"
+  integrity sha512-nO0sq2xdj+zWZaGUjHJSfPQ9tFWf2YUBFZ6J0zzmZWIpcaIet9OQ/B/0zjERMsnd20bzthYLcfn8cPlQpoSQtQ==
   dependencies:
     "@cypress/code-coverage" "^3.11.0"
     "@cypress/webpack-dev-server" "^3.5.2"


### PR DESCRIPTION
This PR includes the following updates:
- Upgrades `@agoric/synpress` to the latest version to utilize new debugging features.
- Revises documentation headings for clarity.
- Updates governance wallets for use in end-to-end testing with `a3p:latest`.