### PR TITLE
test: updated mnemonics for local tests

### DIFF
--- a/tests/e2e/utils.js
+++ b/tests/e2e/utils.js
@@ -25,9 +25,9 @@ export const phrasesList = {
     token: 'USDT_axl',
     network: 'local',
     gov1Phrase:
-      'purse park grow equip size away dismiss used evolve live blouse scorpion enjoy crunch combine day second news off crowd broken crop zoo subject',
+      'such field health riot cost kitten silly tube flash wrap festival portion imitate this make question host bitter puppy wait area glide soldier knee',
     gov2Phrase:
-      'tilt add stairs mandate extra wash choose fashion earth feature reopen until move lazy carbon pledge sure own comfort this nasty clap tower table',
+      'physical immune cargo feel crawl style fox require inhale law local glory cheese bring swear royal spy buyer diesel field when task spin alley',
   },
 };
 


### PR DESCRIPTION
this PR updates the mnemonics for local tests. this had to be done after the tag for the local container was changed from `main` to `latest` in #116 