### PR TITLE
ci: test with custom a3p tag

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -29,6 +29,10 @@ on:
         description: 'Mnemonic for gov2 wallet'
         required: false
         type: string
+      a3p_image_tag:
+        description: 'Docker image tag for the a3p chain to use in testing'
+        required: false
+        type: string
 
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label ||
@@ -68,6 +72,7 @@ jobs:
           SYNPRESS_PROFILE: ${{ env.NETWORK != 'local' && 'daily-tests' || 'synpress' }}
           CYPRESS_AGORIC_NET: ${{ env.NETWORK }}
           # for docker-compose.yml
+          A3P_IMAGE_TAG: ${{ inputs.a3p_image_tag || 'latest' }}
           COMPOSE_DOCKER_CLI_BUILD: 1
           DOCKER_BUILDKIT: 1
           DOCKER_DEFAULT_PLATFORM: linux/amd64

--- a/tests/e2e/docker-compose.yml
+++ b/tests/e2e/docker-compose.yml
@@ -105,7 +105,7 @@ services:
     profiles:
       - synpress
     container_name: agoric_chain
-    image: ghcr.io/agoric/agoric-3-proposals:latest
+    image: ghcr.io/agoric/agoric-3-proposals:${A3P_IMAGE_TAG}
     logging:
       driver: none
     platform: linux/amd64


### PR DESCRIPTION
Adding support to test the `a3p` chain with custom tags.