### PR TITLE
E2E tests for gov3 and gov4 wallets

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -24,14 +24,6 @@ on:
           - emerynet
           - devnet
           - xnet
-      gov1_mnemonic:
-        description: 'Mnemonic for gov1 wallet'
-        required: false
-        type: string
-      gov2_mnemonic:
-        description: 'Mnemonic for gov2 wallet'
-        required: false
-        type: string
       a3p_image_tag:
         description: 'Docker image tag for the a3p chain to use in testing'
         required: false
@@ -92,8 +84,8 @@ jobs:
           ANVIL_FORK_URL: ${{ secrets.ANVIL_FORK_URL }}
           GH_PAT: ${{ secrets.GH_PAT }}
           GH_USERNAME: ${{ secrets.GH_USERNAME }}
-          GOV1_PHRASE: ${{ inputs.gov1_mnemonic || secrets.GOV1_PHRASE }}
-          GOV2_PHRASE: ${{ inputs.gov2_mnemonic || secrets.GOV2_PHRASE }}
+          GOV1_PHRASE: ${{ secrets.GOV1_PHRASE }}
+          GOV2_PHRASE: ${{ secrets.GOV2_PHRASE }}
           GOV3_PHRASE: ${{ secrets.GOV3_PHRASE }}
           GOV4_PHRASE: ${{ secrets.GOV4_PHRASE }}
           # cypress dashboard

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -94,6 +94,8 @@ jobs:
           GH_USERNAME: ${{ secrets.GH_USERNAME }}
           GOV1_PHRASE: ${{ inputs.gov1_mnemonic || secrets.GOV1_PHRASE }}
           GOV2_PHRASE: ${{ inputs.gov2_mnemonic || secrets.GOV2_PHRASE }}
+          GOV3_PHRASE: ${{ secrets.GOV3_PHRASE }}
+          GOV4_PHRASE: ${{ secrets.GOV4_PHRASE }}
           # cypress dashboard
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CYPRESS_PROJECT_ID: ${{ secrets.CYPRESS_PROJECT_ID }}

--- a/tests/e2e/docker-compose.yml
+++ b/tests/e2e/docker-compose.yml
@@ -39,7 +39,8 @@ services:
       - CYPRESS_AGORIC_NET=${CYPRESS_AGORIC_NET}
       - CYPRESS_GOV1_PHRASE=${GOV1_PHRASE}
       - CYPRESS_GOV2_PHRASE=${GOV2_PHRASE}
-      - SECRET_WORDS="orbit bench unit task food shock brand bracket domain regular warfare company announce wheel grape trust sphere boy doctor half guard ritual three ecology"
+      - CYPRESS_GOV3_PHRASE=${GOV3_PHRASE}
+      - CYPRESS_GOV4_PHRASE=${GOV4_PHRASE}
     depends_on:
       - display
       - video

--- a/tests/e2e/specs/proposal.spec.js
+++ b/tests/e2e/specs/proposal.spec.js
@@ -3,11 +3,14 @@ import { phrasesList, getTimeUntilVoteClose, DEFAULT_TIMEOUT } from '../utils';
 
 describe('Make Proposal Tests', () => {
   let startTime;
-  const networkPhrases = phrasesList[Cypress.env('AGORIC_NET') || 'local'];
+  const AGORIC_NET = Cypress.env('AGORIC_NET') || 'local';
+  const networkPhrases = phrasesList[AGORIC_NET];
   const txRetryCount = 2;
 
   context('PSM tests', () => {
     it('should setup two econ committee member wallets', () => {
+      cy.task('info', `${AGORIC_NET}`);
+
       cy.setupWallet({
         secretWords: networkPhrases.gov1Phrase,
         walletName: 'gov1',
@@ -16,6 +19,12 @@ describe('Make Proposal Tests', () => {
         secretWords: networkPhrases.gov2Phrase,
         walletName: 'gov2',
       });
+      if (AGORIC_NET !== 'local') {
+        cy.setupWallet({
+          secretWords: networkPhrases.gov4Phrase,
+          walletName: 'gov4',
+        });
+      }
     });
 
     it('should connect to wallet', () => {
@@ -54,7 +63,12 @@ describe('Make Proposal Tests', () => {
       cy.acceptAccess();
     });
 
-    it('should allow gov1 to create a proposal', () => {
+    it('should allow gov2 to create a proposal', () => {
+      if (AGORIC_NET !== 'local') {
+        cy.switchWallet('gov2');
+        cy.reload();
+      }
+
       // open PSM and select token
       cy.get('button').contains('PSM').click();
       cy.get('button').contains('AUSD').click();
@@ -78,7 +92,7 @@ describe('Make Proposal Tests', () => {
     });
 
     it(
-      'should confirm transaction for gov1 to create a proposal',
+      'should confirm transaction for gov2 to create a proposal',
       {
         retries: {
           runMode: txRetryCount,
@@ -272,6 +286,135 @@ describe('Make Proposal Tests', () => {
     );
 
     it('should wait for proposal to pass', () => {
+      // Wait for 1 minute to pass
+      cy.wait(getTimeUntilVoteClose(startTime, networkPhrases.minutes));
+      cy.visit(`/?agoricNet=${networkPhrases.network}`);
+
+      cy.get('button').contains('History').click();
+
+      // Select the first element proposal containing ATOM and check
+      // its status should be accepted
+      cy.get('code')
+        .contains('VaultFactory - ATOM')
+        .parent()
+        .parent()
+        .parent()
+        .within(() => {
+          cy.get('span').contains('Change Accepted').should('be.visible');
+        });
+    });
+  });
+
+  context('Gov4 tests', () => {
+    it('should allow gov4 to create a proposal', () => {
+      cy.skipWhen(AGORIC_NET === 'local');
+
+      cy.switchWallet('gov4');
+      cy.visit(`/?agoricNet=${networkPhrases.network}`);
+
+      // open Values and select manager 0
+      cy.get('button').contains('Vaults').click();
+      cy.get('button').contains('Select Manager').click();
+      cy.get('button').contains('manager0').click();
+
+      // Change debt limit and proposal time to 1 min
+      cy.get('label')
+        .contains('DebtLimit')
+        .parent()
+        .within(() => {
+          cy.get('input').spread(element => {
+            cy.get('input').clear().type(element.value);
+          });
+        });
+      cy.get('label')
+        .contains('Minutes until close of vote')
+        .parent()
+        .within(() => {
+          cy.get('input').clear().type(networkPhrases.minutes);
+        });
+    });
+
+    it(
+      'should confirm transaction for gov4 to create a proposal',
+      {
+        retries: {
+          runMode: txRetryCount,
+        },
+      },
+      () => {
+        cy.skipWhen(AGORIC_NET === 'local');
+        cy.get('[value="Propose Parameter Change"]').click();
+
+        // Submit proposal and wait for confirmation
+        cy.confirmTransaction();
+        cy.get('p')
+          .contains('sent', { timeout: DEFAULT_TIMEOUT })
+          .should('be.visible')
+          .then(() => {
+            startTime = Date.now();
+          });
+      },
+    );
+
+    it('should allow gov4 to vote on the proposal', () => {
+      cy.skipWhen(AGORIC_NET === 'local');
+      cy.visit(`/?agoricNet=${networkPhrases.network}`);
+
+      // Open vote, click on yes and submit
+      cy.get('button').contains('Vote').click();
+      cy.get('p').contains('YES').click();
+    });
+
+    it(
+      'should confirm transaction for gov4 to vote on the proposal',
+      {
+        retries: {
+          runMode: txRetryCount,
+        },
+      },
+      () => {
+        cy.skipWhen(AGORIC_NET === 'local');
+        cy.get('input:enabled[value="Submit Vote"]').click();
+
+        // Wait for vote to confirm
+        cy.confirmTransaction();
+        cy.get('p')
+          .contains('sent', { timeout: DEFAULT_TIMEOUT })
+          .should('be.visible');
+      },
+    );
+
+    it('should allow gov2 to vote on the proposal', () => {
+      cy.skipWhen(AGORIC_NET === 'local');
+      cy.switchWallet('gov2');
+      cy.visit(`/?agoricNet=${networkPhrases.network}`);
+
+      // Open vote, click on yes and submit
+      cy.get('button').contains('Vote').click();
+      cy.get('p').contains('YES').click();
+    });
+
+    it(
+      'should confirm transaction for gov2 to vote on the proposal',
+      {
+        retries: {
+          runMode: txRetryCount,
+        },
+      },
+      () => {
+        cy.skipWhen(AGORIC_NET === 'local');
+        cy.get('input:enabled[value="Submit Vote"]').click();
+
+        // Wait for vote to confirm
+        cy.confirmTransaction();
+        cy.get('p')
+          .contains('sent', { timeout: DEFAULT_TIMEOUT })
+          .should('be.visible');
+      },
+    );
+
+    it('should wait for proposal to pass', () => {
+      cy.skipWhen(AGORIC_NET === 'local');
       // Wait for 1 minute to pass
       cy.wait(getTimeUntilVoteClose(startTime, networkPhrases.minutes));
       cy.visit(`/?agoricNet=${networkPhrases.network}`);

--- a/tests/e2e/specs/proposal.spec.js
+++ b/tests/e2e/specs/proposal.spec.js
@@ -8,7 +8,7 @@ describe('Make Proposal Tests', () => {
   const txRetryCount = 2;
 
   context('PSM tests', () => {
-    it('should setup two econ committee member wallets', () => {
+    it('should setup 4 econ committee member wallets', () => {
       cy.task('info', `${AGORIC_NET}`);
 
       cy.setupWallet({
@@ -19,12 +19,10 @@ describe('Make Proposal Tests', () => {
         secretWords: networkPhrases.gov2Phrase,
         walletName: 'gov2',
       });
-      if (AGORIC_NET !== 'local') {
-        cy.setupWallet({
-          secretWords: networkPhrases.gov4Phrase,
-          walletName: 'gov4',
-        });
-      }
+      cy.setupWallet({
+        secretWords: networkPhrases.gov4Phrase,
+        walletName: 'gov4',
+      });
     });
 
     it('should connect to wallet', () => {
@@ -307,10 +305,8 @@ describe('Make Proposal Tests', () => {
 
   context('Gov4 tests', () => {
     it('should allow gov4 to create a proposal', () => {
-      cy.skipWhen(AGORIC_NET === 'local');
-
       cy.switchWallet('gov4');
-      cy.visit(`/?agoricNet=${networkPhrases.network}`);
+      cy.reload();
 
       // open Values and select manager 0
       cy.get('button').contains('Vaults').click();
@@ -342,7 +338,6 @@ describe('Make Proposal Tests', () => {
         },
       },
       () => {
-        cy.skipWhen(AGORIC_NET === 'local');
         cy.get('[value="Propose Parameter Change"]').click();
 
         // Submit proposal and wait for confirmation
@@ -357,7 +352,6 @@ describe('Make Proposal Tests', () => {
     );
 
     it('should allow gov4 to vote on the proposal', () => {
-      cy.skipWhen(AGORIC_NET === 'local');
       cy.visit(`/?agoricNet=${networkPhrases.network}`);
 
       // Open vote, click on yes and submit
@@ -373,7 +367,6 @@ describe('Make Proposal Tests', () => {
         },
       },
       () => {
-        cy.skipWhen(AGORIC_NET === 'local');
         cy.get('input:enabled[value="Submit Vote"]').click();
 
         // Wait for vote to confirm
@@ -385,7 +378,6 @@ describe('Make Proposal Tests', () => {
     );
 
     it('should allow gov2 to vote on the proposal', () => {
-      cy.skipWhen(AGORIC_NET === 'local');
       cy.switchWallet('gov2');
       cy.visit(`/?agoricNet=${networkPhrases.network}`);
 
@@ -402,7 +394,6 @@ describe('Make Proposal Tests', () => {
         },
       },
       () => {
-        cy.skipWhen(AGORIC_NET === 'local');
         cy.get('input:enabled[value="Submit Vote"]').click();
 
         // Wait for vote to confirm
@@ -414,7 +405,6 @@ describe('Make Proposal Tests', () => {
     );
 
     it('should wait for proposal to pass', () => {
-      cy.skipWhen(AGORIC_NET === 'local');
       // Wait for 1 minute to pass
       cy.wait(getTimeUntilVoteClose(startTime, networkPhrases.minutes));
       cy.visit(`/?agoricNet=${networkPhrases.network}`);

--- a/tests/e2e/support.js
+++ b/tests/e2e/support.js
@@ -1,1 +1,7 @@
 import '@agoric/synpress/support/index';
+
+Cypress.Commands.add('skipWhen', function (expression) {
+  if (expression) {
+    this.skip();
+  }
+});

--- a/tests/e2e/utils.js
+++ b/tests/e2e/utils.js
@@ -9,6 +9,7 @@ export const phrasesList = {
     networkConfigURL: 'https://emerynet.agoric.net/network-config',
     gov1Phrase: Cypress.env('GOV1_PHRASE'),
     gov2Phrase: Cypress.env('GOV2_PHRASE'),
+    gov4Phrase: Cypress.env('GOV4_PHRASE'),
   },
   devnet: {
     isLocal: false,
@@ -18,6 +19,7 @@ export const phrasesList = {
     networkConfigURL: 'https://devnet.agoric.net/network-config',
     gov1Phrase: Cypress.env('GOV1_PHRASE'),
     gov2Phrase: Cypress.env('GOV2_PHRASE'),
+    gov4Phrase: Cypress.env('GOV4_PHRASE'),
   },
   xnet: {
     isLocal: false,
@@ -27,6 +29,7 @@ export const phrasesList = {
     networkConfigURL: 'https://xnet.agoric.net/network-config',
     gov1Phrase: Cypress.env('GOV1_PHRASE'),
     gov2Phrase: Cypress.env('GOV2_PHRASE'),
+    gov4Phrase: Cypress.env('GOV4_PHRASE'),
   },
   local: {
     isLocal: true,

--- a/tests/e2e/utils.js
+++ b/tests/e2e/utils.js
@@ -9,7 +9,7 @@ export const phrasesList = {
     networkConfigURL: 'https://emerynet.agoric.net/network-config',
     gov1Phrase: Cypress.env('GOV1_PHRASE'),
     gov2Phrase: Cypress.env('GOV2_PHRASE'),
-    gov4Phrase: Cypress.env('GOV4_PHRASE'),
+    gov4Phrase: Cypress.env('GOV3_PHRASE'),
   },
   devnet: {
     isLocal: false,
@@ -19,7 +19,7 @@ export const phrasesList = {
     networkConfigURL: 'https://devnet.agoric.net/network-config',
     gov1Phrase: Cypress.env('GOV1_PHRASE'),
     gov2Phrase: Cypress.env('GOV2_PHRASE'),
-    gov4Phrase: Cypress.env('GOV4_PHRASE'),
+    gov4Phrase: Cypress.env('GOV3_PHRASE'),
   },
   xnet: {
     isLocal: false,
@@ -29,7 +29,7 @@ export const phrasesList = {
     networkConfigURL: 'https://xnet.agoric.net/network-config',
     gov1Phrase: Cypress.env('GOV1_PHRASE'),
     gov2Phrase: Cypress.env('GOV2_PHRASE'),
-    gov4Phrase: Cypress.env('GOV4_PHRASE'),
+    gov4Phrase: Cypress.env('GOV3_PHRASE'),
   },
   local: {
     isLocal: true,
@@ -40,6 +40,8 @@ export const phrasesList = {
       'such field health riot cost kitten silly tube flash wrap festival portion imitate this make question host bitter puppy wait area glide soldier knee',
     gov2Phrase:
       'physical immune cargo feel crawl style fox require inhale law local glory cheese bring swear royal spy buyer diesel field when task spin alley',
+    gov4Phrase:
+      'tackle hen gap lady bike explain erode midnight marriage wide upset culture model select dial trial swim wood step scan intact what card symptom',
   },
 };
 

--- a/tests/e2e/utils.js
+++ b/tests/e2e/utils.js
@@ -9,6 +9,8 @@ export const phrasesList = {
     networkConfigURL: 'https://emerynet.agoric.net/network-config',
     gov1Phrase: Cypress.env('GOV1_PHRASE'),
     gov2Phrase: Cypress.env('GOV2_PHRASE'),
+    // UNTIL https://github.com/Agoric/dapp-econ-gov/issues/144
+    gov3Phrase: Cypress.env('GOV4_PHRASE'),
     gov4Phrase: Cypress.env('GOV3_PHRASE'),
   },
   devnet: {
@@ -19,6 +21,8 @@ export const phrasesList = {
     networkConfigURL: 'https://devnet.agoric.net/network-config',
     gov1Phrase: Cypress.env('GOV1_PHRASE'),
     gov2Phrase: Cypress.env('GOV2_PHRASE'),
+    // UNTIL https://github.com/Agoric/dapp-econ-gov/issues/144
+    gov3Phrase: Cypress.env('GOV4_PHRASE'),
     gov4Phrase: Cypress.env('GOV3_PHRASE'),
   },
   xnet: {
@@ -29,6 +33,8 @@ export const phrasesList = {
     networkConfigURL: 'https://xnet.agoric.net/network-config',
     gov1Phrase: Cypress.env('GOV1_PHRASE'),
     gov2Phrase: Cypress.env('GOV2_PHRASE'),
+    // UNTIL https://github.com/Agoric/dapp-econ-gov/issues/144
+    gov3Phrase: Cypress.env('GOV4_PHRASE'),
     gov4Phrase: Cypress.env('GOV3_PHRASE'),
   },
   local: {
@@ -40,6 +46,9 @@ export const phrasesList = {
       'such field health riot cost kitten silly tube flash wrap festival portion imitate this make question host bitter puppy wait area glide soldier knee',
     gov2Phrase:
       'physical immune cargo feel crawl style fox require inhale law local glory cheese bring swear royal spy buyer diesel field when task spin alley',
+    // UNTIL https://github.com/Agoric/dapp-econ-gov/issues/144
+    gov3Phrase:
+      'spike siege world rather ordinary upper napkin voice brush oppose junior route trim crush expire angry seminar anchor panther piano image pepper chest alone',
     gov4Phrase:
       'tackle hen gap lady bike explain erode midnight marriage wide upset culture model select dial trial swim wood step scan intact what card symptom',
   },


### PR DESCRIPTION
refs https://github.com/Agoric/agoric-sdk/issues/10209

This PR introduces end-to-end(E2E) tests that use gov4 to propose questions and then vote on them using both gov4 and gov2 wallets. The objective is to verify whether gov4, as a new member of the EC committee, can effectively execute tasks related to the EC committee and charter.

The PR also adds E2E tests that ensure gov3 can no longer propose and vote on questions. 